### PR TITLE
update to 4.19.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,21 +40,27 @@ requirements:
     # and appnope is used just optionally in tests
 
 test:
+  imports:
+    - orangewidget.widget
 {% if enable_testingui %}
-  imports:
-    - orangewidget.widget
     - orangewidget.gui
-  source_files:
-    - orangewidget/tests
-  command:
-    - pytest orangewidget/tests
-  requires:
-    - pytest
 {% else %}
-  imports:
-    - orangewidget.widget
     - orangewidget.io
 {% endif %}
+{% if enable_testingui %}
+  source_files:
+    - orangewidget/tests
+{% endif %}
+  command:
+{% if enable_testingui %}
+    - pytest orangewidget/tests
+{% endif %}
+    - pip check
+  requires:
+{% if enable_testingui %}
+    - pytest
+{% endif %}
+    - pip
 
 about:
   home: https://github.com/biolab/orange-widget-base

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,8 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
+  skip: True  # [py<38]
+  skip: True  # [linux and (s390x or ppc64le)]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "orange-widget-base" %}
-{% set version = "4.17.0" %}
+{% set version = "4.19.0" %}
 
 # on our linux builders there is no X11 installed and therefore import
 # test will fail
@@ -15,26 +15,22 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 8897491277ce80a1ea49306552be778ece4d0bf8fad3373388936554c32bccd8
+  sha256: 193055dbee8701ad62d5471c5287b092ce53bb77f7f810ec68bf96816f6acaa2
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
-  skip: True  # [py<36]
-  skip: True  # [linux and (s390x or ppc64le)]
 
 requirements:
   host:
-    - python
+    - python >=3.6
     - pip
-    - setuptools
-    - wheel
   run:
-    - python
+    - python >=3.6
     - matplotlib-base
     - pyqtgraph
     - anyqt >=0.1.0
-    - orange-canvas-core >=0.1.20,<0.2a
+    - orange-canvas-core >=0.1.27,<0.2a
     - typing_extensions >=3.7.4.3
     # appnope is skipped here since if we add it package is not noarch: python anymore
     # and appnope is used just optionally in tests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,8 +39,8 @@ requirements:
     # appnope is skipped here since if we add it package is not noarch: python anymore
     # and appnope is used just optionally in tests
 
-{% if enable_testingui %}
 test:
+{% if enable_testingui %}
   imports:
     - orangewidget.widget
     - orangewidget.gui
@@ -50,6 +50,10 @@ test:
     - pytest orangewidget/tests
   requires:
     - pytest
+{% else %}
+  imports:
+    - orangewidget.widget
+    - orangewidget.io
 {% endif %}
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,16 +19,18 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip: True  # [py<38]
   skip: True  # [linux and (s390x or ppc64le)]
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python >=3.6
+    - python
     - matplotlib-base
     - pyqtgraph
     - anyqt >=0.1.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,12 @@ test:
   imports:
     - orangewidget.widget
     - orangewidget.gui
+  source_files:
+    - orangewidget/tests
+  command:
+    - pytest orangewidget/tests
+  requires:
+    - pytest
 {% endif %}
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - matplotlib-base
     - pyqtgraph
     - anyqt >=0.1.0
-    - orange-canvas-core >=0.1.27,<0.2a
+    - orange-canvas-core >=0.1.28,<0.2a
     - typing_extensions >=3.7.4.3
     # appnope is skipped here since if we add it package is not noarch: python anymore
     # and appnope is used just optionally in tests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - matplotlib-base
     - pyqtgraph
     - anyqt >=0.1.0
-    - orange-canvas-core >=0.1.28,<0.2a
+    - orange-canvas-core >=0.1.27,<0.2a
     - typing_extensions >=3.7.4.3
     # appnope is skipped here since if we add it package is not noarch: python anymore
     # and appnope is used just optionally in tests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: True  # [py<38]
+  skip: True  # [py<36]
   skip: True  # [linux and (s390x or ppc64le)]
 
 requirements:


### PR DESCRIPTION
* Orange3 -> orange-widget-base-feedstock (PKG-1208)
* Enables Orange3 to be updated to =>3.34.0
* Sources from [pypi](https://files.pythonhosted.org/packages/b2/47/3360439c59e994c8ddda2b240a30e82c2757ee876d2157d4bf5cd239e975/orange-widget-base-4.19.0.tar.gz) were checked: setup.py and PKG-INFO
* Updated list of dependencies, build steps and sha
* Update to 4.19.0 was favoured over 4.20.0 because the latter would imply update of canvas-core and therefore anyqt,
  which can be burdensome