### PR TITLE
Update orange-widget-base to 4.22.0

### DIFF
--- a/recipe/abs.yaml
+++ b/recipe/abs.yaml
@@ -1,4 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/url-normalize-feedstock/pr2/ca85677
-  - https://staging.continuum.io/prefect/fs/requests-cache-feedstock/pr2/7b8c1e1
-  - https://staging.continuum.io/prefect/fs/orange-canvas-core-feedstock/pr3/5281936

--- a/recipe/abs.yaml
+++ b/recipe/abs.yaml
@@ -1,0 +1,4 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/url-normalize-feedstock/pr2/ca85677
+  - https://staging.continuum.io/prefect/fs/requests-cache-feedstock/pr2/7b8c1e1
+  - https://staging.continuum.io/prefect/fs/orange-canvas-core-feedstock/pr3/5281936

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,7 +62,7 @@ test:
     - pip
 
 about:
-  home: https://github.com/biolab/orange-widget-base
+  home: https://orangedatamining.com/
   license: GPL-3.0-only
   license_family: GPL
   license_file: LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,8 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 9d5d9a04f6739fb2be4040ad095a0b2e1e6c986df5cc4d86f631532a5c61f6a3
+  patches:
+    - patches/0001-setup.py-Replace-use-of-imp-module.patch
 
 build:
   number: 0
@@ -24,6 +26,9 @@ build:
   skip: True  # [linux and (s390x or ppc64le)]
 
 requirements:
+  build:
+    - patch     # [not win]
+    - m2-patch  # [win]
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,10 +34,9 @@ requirements:
     - matplotlib-base
     - pyqtgraph
     - anyqt >=0.1.0
-    - orange-canvas-core >=0.1.27,<0.2a
+    - orange-canvas-core >=0.1.30,<0.2a
     - typing_extensions >=3.7.4.3
-    # appnope is skipped here since if we add it package is not noarch: python anymore
-    # and appnope is used just optionally in tests
+    - appnope  # [unix]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "orange-widget-base" %}
-{% set version = "4.19.0" %}
+{% set version = "4.22.0" %}
 
 # on our linux builders there is no X11 installed and therefore import
 # test will fail
@@ -15,7 +15,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 193055dbee8701ad62d5471c5287b092ce53bb77f7f810ec68bf96816f6acaa2
+  sha256: 9d5d9a04f6739fb2be4040ad095a0b2e1e6c986df5cc4d86f631532a5c61f6a3
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - anyqt >=0.1.0
     - orange-canvas-core >=0.1.30,<0.2a
     - typing_extensions >=3.7.4.3
-    - appnope  # [unix]
+    - appnope  # [osx]
 
 test:
   imports:

--- a/recipe/patches/0001-setup.py-Replace-use-of-imp-module.patch
+++ b/recipe/patches/0001-setup.py-Replace-use-of-imp-module.patch
@@ -1,0 +1,30 @@
+From eebc02ebde70b6caa54f538e29ef10ff4fac27e9 Mon Sep 17 00:00:00 2001
+From: Ales Erjavec <ales.erjavec@fri.uni-lj.si>
+Date: Fri, 22 Dec 2023 09:44:12 +0100
+Subject: [PATCH] setup.py: Replace use of imp module
+
+---
+ setup.py | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index 043662ce..bc222e70 100755
+--- a/setup.py
++++ b/setup.py
+@@ -119,8 +119,12 @@ if not release:
+         GIT_REVISION = git_version()
+     elif os.path.exists(filename):
+         # must be a source distribution, use existing version file
+-        import imp
+-        version = imp.load_source("orangewidget.version", filename)
++        import importlib.util
++        spec = importlib.util.spec_from_file_location(
++            "orangewidget.version", filename
++        )
++        version = importlib.util.module_from_spec(spec)
++        spec.loader.exec_module(version)
+         GIT_REVISION = version.git_revision
+     else:
+         GIT_REVISION = "Unknown"
+--
+2.32.1 (Apple Git-133)


### PR DESCRIPTION
orange-widget-base 4.22.0

**Destination channel:** {defaults}

### Links

- [PKG-4279](https://anaconda.atlassian.net/browse/PKG-4279) 
- [Upstream repository](https://github.com/biolab/orange-canvas-core/blob/0.1.35)
- Relevant dependency PRs:
  - `url-normalize` > `requests-cache` > `orange-canvas-core` > `orange-widget-base` > `orange3`

### Explanation of changes:
- Updated `version` and `hash`
- Updated dependencies
- Added patch to replace `imp` module with `importlib`
- Added abs.yaml to be removed PRIOR to merge

[PKG-4280]: https://anaconda.atlassian.net/browse/PKG-4280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PKG-4279]: https://anaconda.atlassian.net/browse/PKG-4279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ